### PR TITLE
Key media as before replaced

### DIFF
--- a/Project/Sources/Classes/_widget.4dm
+++ b/Project/Sources/Classes/_widget.4dm
@@ -80,7 +80,9 @@ Class constructor($component : Object; $manifest : Object)
 				This:C1470[$key]:=This:C1470.handler.call(Null:C1517; ":C991($1)").call(Null:C1517; Delete string:C232($manifest[$key]; 1; 7))
 				
 				// ______________________________________________________
-			: ($key="media")
+			: ($key="media")  // OG 2026-0529
+				// Keep back icon from "media" key if any 
+				This:C1470.icon:=This:C1470.getIcon($component.file("Resources/"+String:C10($manifest[$key])); 48)
 				
 				continue
 				
@@ -152,29 +154,32 @@ Class constructor($component : Object; $manifest : Object)
 	End for each 
 	
 	var $path : Text
-	For each ($path; [\
-		"logo.svg"; \
-		"logo.png"; \
-		"Resources/logo.svg"; \
-		"Resources/logo.png"])
+	If (This:C1470.icon=Null:C1517)  // OG 2026-0529
+		// If icon still not initialized, get the new standard
+		For each ($path; [\
+			"logo.svg"; \
+			"logo.png"; \
+			"Resources/logo.svg"; \
+			"Resources/logo.png"])
+			
+			var $file : 4D:C1709.File:=$component.file($path)
+			
+			If (Not:C34($file.exists))
+				
+				continue
+				
+			End if 
+			
+			If ($file.extension=".svg")\
+				 || ($file.extension=".png")
+				
+				break
+				
+			End if 
+		End for each 
 		
-		var $file : 4D:C1709.File:=$component.file($path)
-		
-		If (Not:C34($file.exists))
-			
-			continue
-			
-		End if 
-		
-		If ($file.extension=".svg")\
-			 || ($file.extension=".png")
-			
-			break
-			
-		End if 
-	End for each 
-	
-	This:C1470.icon:=This:C1470.getIcon($file; 48)
+		This:C1470.icon:=This:C1470.getIcon($file; 48)
+	End if 
 	
 	// === === === === === === === === === === === === === === === === === === === === === === === ===
 	// Create an icon from the media


### PR DESCRIPTION
Please restore the old compatibility with the 4DPop.json key "media" : if it exists, this key gives where to find the icon. If no key found, the new behaviour is used. Those are just two little adds into the class "_widget".
My previous pull request was clumsy and with too much noise. This one is just focusing on getting the old behaviour coexisting with the new one (one fixed place for "logo.png" or .svg).